### PR TITLE
Fix typos in prerequisites.md

### DIFF
--- a/docs/Environment/Editors/Prerequisites/prerequisites.md
+++ b/docs/Environment/Editors/Prerequisites/prerequisites.md
@@ -13,23 +13,23 @@ You have 2 options for setting up the compiler infrastructure:
 - _Using Nix and nix-shell_. Assuming you've done setup of [plutus](https://github.com/input-output-hk/plutus) for running `plutus-playground` locally, you already have `ghc` and `cabal` binaries available inside `nix-shell`. 
 - _System-wide installation_. Generally, if you don't want to run `plutus-playground` locally and only want to compile Plutus contracts, you can use your existing haskell installation or install the compiler toolchain without Nix. For using this method, follow the instructions on [ghcup website](https://www.haskell.org/ghcup/).
 
-## HSL (haskell-language-server)
+## HLS (haskell-language-server)
 IDE-like features like auto-completion, type hints, docs and jump-to-definition are provided by a tool called [haskell-language-server](https://github.com/haskell/haskell-language-server/). It is a standalone program that implements [Language Server Protocol (LSP)](https://langserver.org/) for Haskell. Your editor can talk to this program and get the information for showing types, doing auto-completion, etc.
 
 ### Linux
-On Linux, installing the HSL is pretty straightforwad. If you've done Nix setup then you already have `haskell-language-server` binary on your `$PATH` inside `nix-shell`. 
-If you've done installation with `ghcup`, you can install HSL with following command
+On Linux, installing the HLS is pretty straightforwad. If you've done Nix setup then you already have `haskell-language-server` binary on your `$PATH` inside `nix-shell`. 
+If you've done installation with `ghcup`, you can install HLS with following command
    ```bash
-   ghcup install hsl
+   ghcup install hls
    ```
 or you can download pre-built binary from [releases page](https://github.com/haskell/haskell-language-server/releases). Don't forget to put the binary on your `$PATH`. 
 
 ### macOS
 On macOS, the installation is a bit trickier. 
-Due to [linking proglems](https://github.com/haskell/haskell-language-server/issues/1160) HSL crashes when your project uses TemplateHaskell (which Plutus uses a lot) ([issue](https://github.com/haskell/haskell-language-server/issues/1431), [issue](https://github.com/haskell/haskell-language-server/issues/277)). The workaround for this is to compile HSL manually with dynamic linking support. 
+Due to [linking proglems](https://github.com/haskell/haskell-language-server/issues/1160) HLS crashes when your project uses TemplateHaskell (which Plutus uses a lot) ([issue](https://github.com/haskell/haskell-language-server/issues/1431), [issue](https://github.com/haskell/haskell-language-server/issues/277)). The workaround for this is to compile HLS manually with dynamic linking support. 
 
 1. Make sure you have ghc & cabal installed and available on your `$PATH` (either locally or within `nix-shell`)
-2. Clone HSL repo
+2. Clone HLS repo
    ```bash
    $ git clone https://github.com/haskell/haskell-language-server --recurse-submodules
    $ cd haskell-language-server
@@ -40,7 +40,7 @@ Due to [linking proglems](https://github.com/haskell/haskell-language-server/iss
    ghc --version
    # The Glorious Glasgow Haskell Compilation System, version 8.10.4
    ```
-5. Build HSL for your compiler version
+5. Build HLS for your compiler version
    ```bash
    ./cabal-hls-install hls-<version>
    # cabal-hls-install hls-8.10.4

--- a/docs/Environment/Editors/Prerequisites/prerequisites.md
+++ b/docs/Environment/Editors/Prerequisites/prerequisites.md
@@ -26,7 +26,7 @@ or you can download pre-built binary from [releases page](https://github.com/has
 
 ### macOS
 On macOS, the installation is a bit trickier. 
-Due to [linking proglems](https://github.com/haskell/haskell-language-server/issues/1160) HLS crashes when your project uses TemplateHaskell (which Plutus uses a lot) ([issue](https://github.com/haskell/haskell-language-server/issues/1431), [issue](https://github.com/haskell/haskell-language-server/issues/277)). The workaround for this is to compile HLS manually with dynamic linking support. 
+Due to [linking problems](https://github.com/haskell/haskell-language-server/issues/1160) HLS crashes when your project uses TemplateHaskell (which Plutus uses a lot) ([issue](https://github.com/haskell/haskell-language-server/issues/1431), [issue](https://github.com/haskell/haskell-language-server/issues/277)). The workaround for this is to compile HLS manually with dynamic linking support. 
 
 1. Make sure you have ghc & cabal installed and available on your `$PATH` (either locally or within `nix-shell`)
 2. Clone HLS repo


### PR DESCRIPTION
This file used the consistently misspelled "HSL" instead of "HLS".